### PR TITLE
hotfix jugador_class

### DIFF
--- a/classes/Jugador.class.php
+++ b/classes/Jugador.class.php
@@ -25,7 +25,6 @@ class Jugador
         $this->setPropuestas($propuestas);
         $this->setPuntos($puntos);
         $this->setPersonajes($personajes);
-        $this->setPersonajes($propuestas);
         $this->setImgData($imagen);
     }
 


### PR DESCRIPTION
Se corrige el constructor de Jugador.

-> Se elimina la linea del constructor que sobrescribía el array de personajes con el valor de propuestas